### PR TITLE
Add "to" date argument.

### DIFF
--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -30,10 +30,19 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
     const fromDate = argv.from
         ? parse(argv.from as string, DATE_FORMAT, new Date())
         : undefined;
+    const toDate = argv.to
+        ? parse(argv.to as string, DATE_FORMAT, new Date())
+        : undefined;
 
     if (fromDate && isNaN(fromDate.getTime())) {
         throw new Error(
             `Invalid from date: '${argv.from}'. Expected a date in the format: ${DATE_FORMAT}`
+        );
+    }
+
+    if (toDate && isNaN(toDate.getTime())) {
+        throw new Error(
+            `Invalid "to" date: '${argv.to}'. Expected a date in the format: ${DATE_FORMAT}`
         );
     }
 
@@ -106,6 +115,11 @@ export default {
             .describe(
                 'from',
                 `Import transactions on or after this date (${DATE_FORMAT})`
+            )
+            .string('to')
+            .describe(
+                'from',
+                `Import transactions up to this date (${DATE_FORMAT})`
             );
     },
     handler: (argv) => handleCommand(argv),

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -130,16 +130,19 @@ class Importer {
     async importTransactions({
         accountMapping,
         from,
+        to,
         isDryRun = false,
     }: {
         accountMapping: Map<MonMonAccount, Account>;
         from?: Date;
+        to?: Date;
         isDryRun?: boolean;
     }) {
         const fromDate = from ?? subMonths(new Date(), 1);
         const earliestImportDate = this.budgetConfig.earliestImportDate
             ? new Date(this.budgetConfig.earliestImportDate)
             : null;
+        const toDate = to;
 
         const importDate =
             earliestImportDate && earliestImportDate > fromDate
@@ -157,6 +160,7 @@ class Importer {
 
         let monMonTransactions = await getTransactions({
             from: importDate,
+            to: toDate
         });
 
         if (monMonTransactions.length === 0) {


### PR DESCRIPTION
btw, thanks for writing the importer!

I ran into an issue trying to import all transactions at once. Namely:
```
[WARN] Earliest import date is set to 2021-01-01. Using this date instead of 2021-01-01.
Error:  RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded
    at Socket.onChildStdout (node:child_process:490:14)
    at Socket.emit (node:events:514:28)
    at addChunk (node:internal/streams/readable:545:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:495:3)
    at Readable.push (node:internal/streams/readable:375:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
  code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
  cmd: 'osascript -e \n' +
    '        tell application "MoneyMoney"\n' +
    '            export transactions from date "2021-01-01" as "plist"\n' +
    '        end tell\n' +
    '    ',
  stdout: '<?xml version="1.0" encoding="UT
```
On a related note it would be great to bubble up this error [here](https://github.com/NikxDa/node-moneymoney/blob/main/src/utils.ts#L49) instead of returning "Unknown error".

In any case, to address this I also added the "to" date in order to import shorter timespans, which seems to work well.