### PR TITLE
feat: make OpenAI model configurable in payee transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ A configuration document looks like this:
 # Payee transformation
 [payeeTransformation]
 enabled = false
-openAiApiKey = "<openAiKey>"
-model = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use (default: gpt-3.5-turbo)
+openAiApiKey = "<openAiKey>"  # Your OpenAI API key
+openAiModel = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use (default: gpt-3.5-turbo)
 
 # Import settings
 [import]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A configuration document looks like this:
 [payeeTransformation]
 enabled = false
 openAiApiKey = "<openAiKey>"
+model = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use (default: gpt-3.5-turbo)
 
 # Import settings
 [import]

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -17,7 +17,9 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
     const payeeTransformer =
         config.payeeTransformation.enabled &&
         config.payeeTransformation.openAiApiKey
-            ? new PayeeTransformer(config.payeeTransformation.openAiApiKey)
+            ? new PayeeTransformer(config.payeeTransformation.openAiApiKey, {
+                  model: config.payeeTransformation.model || 'gpt-3.5-turbo',
+              })
             : undefined;
 
     if (config.actualServers.length === 0) {

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -17,10 +17,13 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
     const payeeTransformer =
         config.payeeTransformation.enabled &&
         config.payeeTransformation.openAiApiKey
-            ? new PayeeTransformer({
-                  openAiApiKey: config.payeeTransformation.openAiApiKey,
-                  openAiModel: config.payeeTransformation.openAiModel,
-              }, logger)
+            ? new PayeeTransformer(
+                  {
+                      openAiApiKey: config.payeeTransformation.openAiApiKey,
+                      openAiModel: config.payeeTransformation.openAiModel,
+                  },
+                  logger
+              )
             : undefined;
 
     if (config.actualServers.length === 0) {

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -20,7 +20,7 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
             ? new PayeeTransformer({
                   openAiApiKey: config.payeeTransformation.openAiApiKey,
                   openAiModel: config.payeeTransformation.openAiModel,
-              })
+              }, logger)
             : undefined;
 
     if (config.actualServers.length === 0) {

--- a/src/commands/import.command.ts
+++ b/src/commands/import.command.ts
@@ -17,8 +17,9 @@ const handleCommand = async (argv: ArgumentsCamelCase) => {
     const payeeTransformer =
         config.payeeTransformation.enabled &&
         config.payeeTransformation.openAiApiKey
-            ? new PayeeTransformer(config.payeeTransformation.openAiApiKey, {
-                  model: config.payeeTransformation.model || 'gpt-3.5-turbo',
+            ? new PayeeTransformer({
+                  openAiApiKey: config.payeeTransformation.openAiApiKey,
+                  openAiModel: config.payeeTransformation.openAiModel,
               })
             : undefined;
 

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -1,12 +1,18 @@
 import OpenAI from 'openai';
 
+interface PayeeTransformerConfig {
+    model: string;
+}
+
 class PayeeTransformer {
     private openai: OpenAI;
+    private config: PayeeTransformerConfig;
 
-    constructor(openAiApiKey: string) {
+    constructor(openAiApiKey: string, config: PayeeTransformerConfig = { model: 'gpt-3.5-turbo' }) {
         this.openai = new OpenAI({
             apiKey: openAiApiKey,
         });
+        this.config = config;
     }
 
     public async transformPayees(payeeList: string[]) {
@@ -14,7 +20,7 @@ class PayeeTransformer {
 
         try {
             const response = await this.openai.chat.completions.create({
-                model: 'gpt-3.5-turbo',
+                model: this.config.model,
                 messages: [
                     { role: 'system', content: prompt },
                     { role: 'user', content: payeeList.join('\n') },

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -8,7 +8,10 @@ class PayeeTransformer {
     private openai: OpenAI;
     private config: PayeeTransformerConfig;
 
-    constructor(openAiApiKey: string, config: PayeeTransformerConfig = { model: 'gpt-3.5-turbo' }) {
+    constructor(
+        openAiApiKey: string,
+        config: PayeeTransformerConfig = { model: 'gpt-3.5-turbo' }
+    ) {
         this.openai = new OpenAI({
             apiKey: openAiApiKey,
         });

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -23,7 +23,9 @@ class PayeeTransformer {
         const prompt = this.generatePrompt();
 
         try {
-            this.logger.debug(`Starting payee transformation with model: ${this.config.openAiModel}`);
+            this.logger.debug(
+                `Starting payee transformation with model: ${this.config.openAiModel}`
+            );
 
             // Validate model before proceeding
             await this.validateModel();
@@ -45,13 +47,17 @@ class PayeeTransformer {
             try {
                 return JSON.parse(cleanedOutput) as { [key: string]: string };
             } catch (parseError) {
-                this.logger.error(`Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`);
+                this.logger.error(
+                    `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : 'Unknown error'}`
+                );
                 this.logger.debug(`Raw response: ${output}`);
                 return null;
             }
         } catch (error) {
             if (error instanceof Error) {
-                this.logger.error(`Error in payee transformation: ${error.message}`);
+                this.logger.error(
+                    `Error in payee transformation: ${error.message}`
+                );
             }
             return null;
         }
@@ -104,7 +110,9 @@ class PayeeTransformer {
 
     private cleanJsonResponse(response: string): string {
         // Remove markdown code block markers
-        let cleaned = response.replace(/```json\s*/g, '').replace(/```\s*$/g, '');
+        let cleaned = response
+            .replace(/```json\s*/g, '')
+            .replace(/```\s*$/g, '');
 
         // Trim whitespace
         cleaned = cleaned.trim();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -49,7 +49,7 @@ export const configSchema = z
         payeeTransformation: z.object({
             enabled: z.boolean(),
             openAiApiKey: z.string().optional(),
-            model: z.string().optional(),
+            openAiModel: z.string().optional().default('gpt-3.5-turbo'),
         }),
         import: z.object({
             importUncheckedTransactions: z.boolean(),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -49,6 +49,7 @@ export const configSchema = z
         payeeTransformation: z.object({
             enabled: z.boolean(),
             openAiApiKey: z.string().optional(),
+            model: z.string().optional(),
         }),
         import: z.object({
             importUncheckedTransactions: z.boolean(),


### PR DESCRIPTION
## Description
This PR adds the ability to configure which OpenAI model is used for payee transformation. By default, it continues to use 'gpt-3.5-turbo', but users can now specify a different model in their configuration.

## Changes
- Added `model` field to the payee transformation configuration
- Updated PayeeTransformer to accept model configuration
- Added documentation for the new configuration option
- Maintains backward compatibility by defaulting to 'gpt-3.5-turbo'

## Example Configuration
```toml
[payeeTransformation]
enabled = true
openAiApiKey = "your-api-key"
model = "gpt-4o"  # Optional: defaults to "gpt-3.5-turbo" if not specified
```

## Testing
- [x] Verified that the default model (gpt-3.5-turbo) works as before
- [x] Tested with a custom model configuration
- [x] Verified backward compatibility