### PR TITLE
feat: add custom prompt overwrite option for payee transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A configuration document looks like this:
 enabled = false
 openAiApiKey = "<openAiKey>"  # Your OpenAI API key
 openAiModel = "gpt-3.5-turbo"  # Optional: Specify the OpenAI model to use (default: gpt-3.5-turbo)
+prompt = "<custom prompt>"  # Optional: Override the default payee transformation instructions
 
 # Import settings
 [import]
@@ -62,7 +63,7 @@ password = ""
 
 A short summary:
 
--   **Payee transformation** allows the automatic conversion of payee names to human-readable formats, e.g. "AMAZN S.A.R.L" to "Amazon". In order for this to function, you also need to provide a valid OpenAI API key. You can generate this key at [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys).
+-   **Payee transformation** allows the automatic conversion of payee names to human-readable formats, e.g. "AMAZN S.A.R.L" to "Amazon". In order for this to function, you also need to provide a valid OpenAI API key. You can generate this key at [https://platform.openai.com/api-keys](https://platform.openai.com/api-keys). You can optionally override the default prompt with custom instructions if you need different transformation rules.
 -   **Import settings** allow you to customize the import behavior, e.g. whether unchecked transactions should be imported.
 -   **Actual servers** specify which servers should be imported to
 -   **Budget configurations** describe the budget files per server which are import targets. The sync ID can be grabbed from the Actual web interface by navigating to settings, then advanced settings. If the budget file is end-to-end encrypted, the details need to be provided here.
@@ -94,6 +95,17 @@ purposePatterns = []
 ```
 
 The above configuration would ignore all transactions that have a comment containing the string `[actual-ignore]`.
+
+### Custom payee transformation prompt
+
+If you want to adjust how payees are renamed, you can supply a custom prompt for the transformer. The prompt is optional, and when omitted the default instructions are used.
+
+```
+[payeeTransformation]
+prompt = "Keep the payee names as short as possible."
+```
+
+You can provide any text that suits your needs, for example to enforce specific naming conventions.
 
 ### Earliest import date
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,6 @@ purposePatterns = []
 
 The above configuration would ignore all transactions that have a comment containing the string `[actual-ignore]`.
 
-### Custom payee transformation prompt
-
-If you want to adjust how payees are renamed, you can supply a custom prompt for the transformer. The prompt is optional, and when omitted the default instructions are used.
-
-```
-[payeeTransformation]
-prompt = "Keep the payee names as short as possible."
-```
-
-You can provide any text that suits your needs, for example to enforce specific naming conventions.
-
 ### Earliest import date
 
 Each budget can specify an earliest import date. This can be useful when starting to use the importer with an already existing budget in order to prevent duplicates from being imported. The importer will ignore any transactions from before the specified date.

--- a/src/utils/PayeeTransformer.ts
+++ b/src/utils/PayeeTransformer.ts
@@ -103,6 +103,10 @@ class PayeeTransformer {
     }
 
     private generatePrompt() {
+        if (this.config.prompt?.trim()) {
+            return this.config.prompt;
+        }
+
         return `
             You are now a model trained to classify bank account transactions. You will receive
             a list of payees as they appear in the source transactions, and you will return

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -48,6 +48,7 @@ const payeeTransformationSchema = z.object({
     enabled: z.boolean(),
     openAiApiKey: z.string().optional(),
     openAiModel: z.string().optional().default('gpt-3.5-turbo'),
+    prompt: z.string().optional(),
 });
 
 export const configSchema = z


### PR DESCRIPTION
## Summary
This PR adds the ability to provide a custom prompt for payee transformation, allowing users to override the default transformation instructions.

## Changes
- Extended `payeeTransformation` config schema with optional `prompt` field
- Modified `PayeeTransformer.generatePrompt()` to use custom prompt when provided
- Updated documentation with usage examples

## Fixes
Closes #40 