### PR TITLE
fix: remove async from duplicate filter to enable proper filtering

### DIFF
--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -186,7 +186,8 @@ class Importer {
             createTransactions = createTransactions.filter((transaction) => {
                 const transactionExists = existingActualTransactions.some(
                     (existingTransaction) =>
-                        existingTransaction.imported_id === transaction.imported_id
+                        existingTransaction.imported_id ===
+                        transaction.imported_id
                 );
                 return !transactionExists;
             });

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -183,17 +183,13 @@ class Importer {
             }
 
             // Filter out transactions that already exist in Actual
-            createTransactions = createTransactions.filter(
-                async (transaction) => {
-                    const transactionExists = existingActualTransactions.some(
-                        (existingTransaction) =>
-                            existingTransaction.imported_id ===
-                            transaction.imported_id
-                    );
-
-                    return !transactionExists;
-                }
-            );
+            createTransactions = createTransactions.filter((transaction) => {
+                const transactionExists = existingActualTransactions.some(
+                    (existingTransaction) =>
+                        existingTransaction.imported_id === transaction.imported_id
+                );
+                return !transactionExists;
+            });
 
             if (createTransactions.length === 0) {
                 this.logger.debug(


### PR DESCRIPTION
## Problem

The duplicate transaction filter in `Importer.ts` was broken due to an async callback in `Array.filter()`. This caused all transactions to pass through the filter, leading to unnecessary OpenAI API calls for payee transformation of duplicate transactions.

## Solution

Remove the `async` keyword from the filter callback since `Array.some()` is already synchronous. This enables proper duplicate filtering before payee transformation.

## Impact

- Fixes broken duplicate detection that was causing all transactions to pass through
- Prevents unnecessary OpenAI API calls for duplicate transactions  
- Reduces API costs and improves import performance
- No behavior change for users - duplicate detection still works via Actual Budget API

## Testing

Verified with real import showing proper filtering:
- Previously all transactions would have been sent to the API
- Now found 146 total transactions in MoneyMoney
- All accounts correctly show "No new transactions found" 
- No OpenAI calls made for existing transactions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the transaction import filtering to remove unnecessary asynchronous overhead. Result: import runs more efficiently while preserving existing behavior and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->