### PR TITLE
feat: allow importing comments from MoneyMoney

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ prompt = "<custom prompt>"  # Optional: Override the default payee transformatio
 [import]
 importUncheckedTransactions = true
 synchronizeClearedStatus = true
-importComments = false # Imports MoneyMoney comments into Actual 
+importComments = false # Optional: Import MoneyMoney comments into Actual 
+commentPrefix = "MoneyMoney Comment: " # Optional: Set a prefix for MoneyMoney comments inside the notes
 
 # Actual servers, you can add multiple servers
 [[actualServers]]

--- a/src/utils/Importer.ts
+++ b/src/utils/Importer.ts
@@ -278,10 +278,14 @@ class Importer {
     private async convertToActualTransaction(
         transaction: MonMonTransaction
     ): Promise<CreateTransaction> {
-        const transactionNotes =
+        const transactionNotes = [
+            transaction.purpose,
             transaction.comment && this.config.import.importComments
-                ? `${transaction.purpose} | MoneyMoney Comment: ${transaction.comment}`
-                : transaction.purpose;
+                ? `${this.config.import.commentPrefix}${transaction.comment}`
+                : undefined,
+        ]
+            .filter(Boolean)
+            .join(' | ');
 
         return {
             date: format(transaction.valueDate, 'yyyy-MM-dd'),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -58,6 +58,7 @@ export const configSchema = z
             importUncheckedTransactions: z.boolean(),
             synchronizeClearedStatus: z.boolean().default(true),
             importComments: z.boolean().default(false),
+            commentPrefix: z.string().default('MoneyMoney Comment: '),
             ignorePatterns: z
                 .object({
                     commentPatterns: z.array(z.string()).optional(),


### PR DESCRIPTION
fixes #252 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to include MoneyMoney comments in transaction notes during import (disabled by default).
  * Added a configuration option to set a custom prefix for imported comments; when enabled, comments are appended to notes using the configured prefix.
  
<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->