### PR TITLE
feat(deps): bump moneymoney to allow larger imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@actual-app/api": "^26.2.1",
                 "chalk": "^5.6.2",
                 "date-fns": "^4.1.0",
-                "moneymoney": "^1.2.2",
+                "moneymoney": "^1.3.0",
                 "node-fetch": "^3.3.2",
                 "openai": "^6.25.0",
                 "toml": "^3.0.0",
@@ -4113,9 +4113,9 @@
             "license": "MIT"
         },
         "node_modules/moneymoney": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/moneymoney/-/moneymoney-1.2.2.tgz",
-            "integrity": "sha512-md9UwkQwa8Z+pzlmoN3tXTOobq3hcjvRMxEN3nHBdWi19HpecuN0MQYzvIPHXrRnjJkMVY6U7Ym8ZXmP7EI6HA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/moneymoney/-/moneymoney-1.3.0.tgz",
+            "integrity": "sha512-dgEs5QNH/36Fu7WGgh6MdlloNPmvCbp4TdgqNpPvtjxDBiCMPBEAvVOdQNQUVKvnzjsvYjBDEjYmtHS0FjkAAA==",
             "license": "MIT",
             "dependencies": {
                 "plist": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@actual-app/api": "^26.2.1",
         "chalk": "^5.6.2",
         "date-fns": "^4.1.0",
-        "moneymoney": "^1.2.2",
+        "moneymoney": "^1.3.0",
         "node-fetch": "^3.3.2",
         "openai": "^6.25.0",
         "toml": "^3.0.0",


### PR DESCRIPTION
This update increases the maximum buffer size from 200kb to 5mb to allow larger imports before failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated moneymoney dependency to version 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->